### PR TITLE
Fix broken header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+name: GriefPrevention
+title: null

--- a/index.md
+++ b/index.md
@@ -1,6 +1,4 @@
-<p align="center">
-<img alt="GriefPrevention" width=100% height=auto src="https://repository-images.githubusercontent.com/68339667/9b3f7c00-ce61-11ea-82d1-208eaa0606e8">
-</p>
+![GriefPrevention](https://repository-images.githubusercontent.com/68339667/9b3f7c00-ce61-11ea-82d1-208eaa0606e8)
 
 <h1 align="center">The self-service anti-griefing plugin for Minecraft servers since 2011</h1>
 


### PR DESCRIPTION
Moving the image outside of the `<p>` element appears to have make Jekyll happy; this means the header is no longer centred, however as it's the widest element on the page centering isn't required.

Also adds `_config.yml` to remove the `<h1>` automatically added by the Jekyll template.